### PR TITLE
Fix "lookAhead" value in linear example configs

### DIFF
--- a/example/persistent-linear/README.md
+++ b/example/persistent-linear/README.md
@@ -39,7 +39,7 @@ config:
         name: LinearPrediction
         perInterval: 1
         linear:
-          lookAhead: 10000
+          lookAhead: 10
           storedValues: 6
       decisionType: "maximum"
       metrics:

--- a/example/simple-linear/README.md
+++ b/example/simple-linear/README.md
@@ -33,7 +33,7 @@ config:
         name: LinearPrediction
         perInterval: 1
         linear:
-          lookAhead: 10000
+          lookAhead: 10
           storedValues: 6
       decisionType: "maximum"
       metrics:


### PR DESCRIPTION
this lookAhead config value is actually in seconds, not milliseconds:
https://github.com/jthomperoo/predictive-horizontal-pod-autoscaler/blob/7911fe6a26ed5533ba1700e839cd95eb51ff187e/prediction/linear/linear.go#L49
which was why I was initially confused that the predictions seemed way off (predicting the load 3 hours ahead w/ past 60 seconds of data is not very accurate lol).

This PR fixes the values in the readme so the prediction is _actually_ 10 seconds ahead, not 3 hours ahead.